### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -11,17 +11,17 @@
 # Methods and Functions (KEYWORD2)
 #######################################
 
-Initialize KEYWORD2
-Update     KEYWORD2
-Read       KEYWORD2
-Write      KEYWORD2
-Reset      KEYWORD2
+Initialize	KEYWORD2
+Update	KEYWORD2
+Read	KEYWORD2
+Write	KEYWORD2
+Reset	KEYWORD2
 
 
 #######################################
 # Instances (KEYWORD3)
 #######################################
-SmoozPot   KEYWORD3
+SmoozPot	KEYWORD3
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords